### PR TITLE
Side navigation width change.

### DIFF
--- a/src/js/components/SplitLayout.js
+++ b/src/js/components/SplitLayout.js
@@ -14,7 +14,7 @@ class SplitLayout extends React.Component {
         this.state = {
             currentSize: 325,
             maxSize: 325,
-            minSize: 100,
+            minSize: 200,
             fixed: false,
             collapsed: false,
             dragging: false,


### PR DESCRIPTION
The side nav was too small when reading a lesson, made the min-width larger.